### PR TITLE
Better Errors

### DIFF
--- a/dinao/backend/base.py
+++ b/dinao/backend/base.py
@@ -108,7 +108,12 @@ class ConnectionPool(ABC):
 
         The db_url is expected to be in the following format::
 
-            "{db_backend}+{driver}://{username}:{password}@{hostname}:{port}/{db_name}?{optional_ars}"
+            "{db_backend}+{driver}://{username}:{password}@{hostname}:{port}/{db_name}?{optional_args}"
+
+        Supported `optional_args` include:
+
+            * defer, a boolean specifying pool initialization should be deferred until a connection is needed, defaults
+              to False
 
         :param db_url: a url with the described format
         """

--- a/dinao/backend/postgres.py
+++ b/dinao/backend/postgres.py
@@ -19,11 +19,11 @@ class ConnectionPoolPSQLPsycopg2(ConnectionPool):
 
         The db_url is expected to be in the following format::
 
-            "postgres+psycopg2://{username}:{password}@{hostname}:{port}/{db_name}?{optional_ars}"
+            "postgres+psycopg2://{username}:{password}@{hostname}:{port}/{db_name}?{optional_args}"
 
-        Supported `optional_ars` include:
+        Supported `optional_args` include:
 
-            * schema, sets the search path of the connections, defaults to "public"
+            * schema, a list of strings that sets the search path of the connections, defaults to "public"
             * pool_min_conn, an integer specifying the minimum connections to keep in the pool, defaults to 1
             * pool_max_conn, an integer specifying the maximum connections to keep in the pool, defaults to 1
             * pool_threaded, a boolean specifying a threaded pool should be used, defaults to False

--- a/dinao/binding/binders.py
+++ b/dinao/binding/binders.py
@@ -24,7 +24,7 @@ class FunctionBinder:
 
     def _suppressed_raise(self, exc: Exception):
         if self._verbose_trace:
-            raise exc
+            raise exc  # pragma: no cover
         # Try to cut down on the traces so the user gets closer to the issue in their code
         raise exc.with_traceback(None) from exc
 

--- a/dinao/binding/errors.py
+++ b/dinao/binding/errors.py
@@ -29,3 +29,9 @@ class BadReturnType(SignatureError):
     """Raised when a return hint specifies a type that cannot be used for mapping in the context of the binding."""
 
     pass
+
+
+class MissingTemplateArgument(SignatureError):
+    """Raised when a template specifies an argument not found in its bounded function's signature."""
+
+    pass

--- a/dinao/binding/errors.py
+++ b/dinao/binding/errors.py
@@ -7,6 +7,12 @@ class BindingError(Exception):
     pass
 
 
+class TemplateError(BindingError):
+    """Raised when parsing a template fails."""
+
+    pass
+
+
 class FunctionAlreadyBound(BindingError):
     """Raised when a function is bound more than once to a query, execution, or transaction."""
 

--- a/dinao/binding/errors.py
+++ b/dinao/binding/errors.py
@@ -7,6 +7,12 @@ class BindingError(Exception):
     pass
 
 
+class FunctionAlreadyBound(BindingError):
+    """Raised when a function is bound more than once to a query, execution, or transaction."""
+
+    pass
+
+
 class SignatureError(BindingError):
     """Base exception for binding errors related to function signature inspection."""
 

--- a/dinao/binding/templating.py
+++ b/dinao/binding/templating.py
@@ -49,6 +49,10 @@ class Template:
             self._munged_template += node
         self._argument_names = tuple(self._argument_names)
 
+    def __str__(self) -> str:
+        """Simple representation of the template."""
+        return self._sql_template
+
     @property
     def arguments(self) -> typing.Tuple[typing.Tuple[str]]:
         """Return a tuple of tuples representing the argument identifiers used in the template."""

--- a/dinao/binding/templating.py
+++ b/dinao/binding/templating.py
@@ -2,10 +2,12 @@
 
 import typing
 
+from dinao.binding.errors import TemplateError
+
 # fmt: off
 from pyparsing import (  # noqa: I101
     alphanums, alphas, printables,
-    Combine, Forward, Group, OneOrMore, Suppress, White, Word, ZeroOrMore
+    Combine, Forward, Group, OneOrMore, Suppress, White, Word, ZeroOrMore, ParseBaseException
 )
 # fmt: on
 
@@ -39,8 +41,10 @@ class Template:
         self._mung_symbol = mung_symbol
         self._argument_names = []
         self._munged_template = ""
-        # TODO: Try/Except here, rethrow a more descriptive error with explict class
-        nodes = self.GRAMMAR.parseString(sql_template, parseAll=True)
+        try:
+            nodes = self.GRAMMAR.parseString(sql_template, parseAll=True)
+        except ParseBaseException as pbx:
+            raise TemplateError(f"{pbx.msg}:\n{pbx.line}\n{(' '*(pbx.col -1 ))}^")
         for node in nodes:
             if not isinstance(node, str):
                 node = tuple(map(str, node))
@@ -50,7 +54,7 @@ class Template:
         self._argument_names = tuple(self._argument_names)
 
     def __str__(self) -> str:
-        """Simple representation of the template."""
+        """Return a simple representation of the template."""
         return self._sql_template
 
     @property

--- a/tests/binding/test_binders.py
+++ b/tests/binding/test_binders.py
@@ -3,7 +3,7 @@
 from typing import List, Tuple
 
 from dinao.binding.binders import FunctionBinder
-from dinao.binding.errors import BadReturnType, FunctionAlreadyBound, MissingTemplateArgument
+from dinao.binding.errors import BadReturnType, FunctionAlreadyBound, MissingTemplateArgument, TemplateError
 
 import pytest
 
@@ -108,6 +108,17 @@ def test_binder_execute_bad_type(binder_and_pool: Tuple[FunctionBinder, MockConn
             pass  # pragma: no cover
 
 
+def test_binder_raises_for_template(binder_and_pool: Tuple[FunctionBinder, MockConnectionPool]):
+    """Tests that a bad template causes an error at binding time."""
+    binder, _ = binder_and_pool
+
+    with pytest.raises(TemplateError, match="#{arg1"):
+
+        @binder.execute("INSERT INTO table #{arg1")
+        def should_raise_0(arg1: str) -> List:
+            pass  # pragma: no cover
+
+
 def test_double_binding_raises(binder_and_pool: Tuple[FunctionBinder, MockConnectionPool]):
     """Tests that binding a function more than once results in an error."""
     binder, _ = binder_and_pool
@@ -143,4 +154,4 @@ def test_args_mismatch_raises(binder_and_pool: Tuple[FunctionBinder, MockConnect
 
         @binder.execute("INSERT INTO table (#{arg})")
         def should_raise_4(some_arg: str):
-            pass
+            pass  # pragma: no cover

--- a/tests/binding/test_binders.py
+++ b/tests/binding/test_binders.py
@@ -111,10 +111,25 @@ def test_binder_execute_bad_type(binder_and_pool: Tuple[FunctionBinder, MockConn
 def test_double_binding_raises(binder_and_pool: Tuple[FunctionBinder, MockConnectionPool]):
     """Tests that binding a function more than once results in an error."""
     binder, _ = binder_and_pool
+    match = "has already been bounded by"
 
-    with pytest.raises(FunctionAlreadyBound, match="has already been bounded by"):
+    with pytest.raises(FunctionAlreadyBound, match=match):
 
-        @binder.execute("UPDATE TABLE SET col = #{arg1}")
+        @binder.execute("UPDATE table SET col = #{arg1}")
         @binder.execute("INSERT INTO TABLE (#{arg1})")
+        def should_raise(arg1: str):
+            pass  # pragma: no cover
+
+    with pytest.raises(FunctionAlreadyBound, match=match):
+
+        @binder.execute("UPDATE table SET col = #{arg1}")
+        @binder.query("SELECT * FROM table WHERE col = #{arg1})")
+        def should_raise(arg1: str):
+            pass  # pragma: no cover
+
+    with pytest.raises(FunctionAlreadyBound, match=match):
+
+        @binder.execute("UPDATE table SET col = #{arg1}")
+        @binder.transaction()
         def should_raise(arg1: str):
             pass  # pragma: no cover

--- a/tests/binding/test_binders.py
+++ b/tests/binding/test_binders.py
@@ -117,19 +117,19 @@ def test_double_binding_raises(binder_and_pool: Tuple[FunctionBinder, MockConnec
 
         @binder.execute("UPDATE table SET col = #{arg1}")
         @binder.execute("INSERT INTO TABLE (#{arg1})")
-        def should_raise(arg1: str):
+        def should_raise_1(arg1: str):
             pass  # pragma: no cover
 
     with pytest.raises(FunctionAlreadyBound, match=match):
 
         @binder.execute("UPDATE table SET col = #{arg1}")
         @binder.query("SELECT * FROM table WHERE col = #{arg1})")
-        def should_raise(arg1: str):
+        def should_raise_2(arg1: str):
             pass  # pragma: no cover
 
     with pytest.raises(FunctionAlreadyBound, match=match):
 
         @binder.execute("UPDATE table SET col = #{arg1}")
         @binder.transaction()
-        def should_raise(arg1: str):
+        def should_raise_3(arg1: str):
             pass  # pragma: no cover

--- a/tests/binding/test_binders.py
+++ b/tests/binding/test_binders.py
@@ -3,7 +3,7 @@
 from typing import List, Tuple
 
 from dinao.binding.binders import FunctionBinder
-from dinao.binding.errors import BadReturnType
+from dinao.binding.errors import BadReturnType, FunctionAlreadyBound
 
 import pytest
 
@@ -105,4 +105,16 @@ def test_binder_execute_bad_type(binder_and_pool: Tuple[FunctionBinder, MockConn
 
         @binder.execute("INSERT INTO TABLE (#{arg1})")
         def should_raise(arg1: str) -> List:
+            pass  # pragma: no cover
+
+
+def test_double_binding_raises(binder_and_pool: Tuple[FunctionBinder, MockConnectionPool]):
+    """Tests that binding a function more than once results in an error."""
+    binder, _ = binder_and_pool
+
+    with pytest.raises(FunctionAlreadyBound, match="has already been bounded by"):
+
+        @binder.execute("UPDATE TABLE SET col = #{arg1}")
+        @binder.execute("INSERT INTO TABLE (#{arg1})")
+        def should_raise(arg1: str):
             pass  # pragma: no cover

--- a/tests/binding/test_binders.py
+++ b/tests/binding/test_binders.py
@@ -3,7 +3,7 @@
 from typing import List, Tuple
 
 from dinao.binding.binders import FunctionBinder
-from dinao.binding.errors import BadReturnType, FunctionAlreadyBound
+from dinao.binding.errors import BadReturnType, FunctionAlreadyBound, MissingTemplateArgument
 
 import pytest
 
@@ -133,3 +133,14 @@ def test_double_binding_raises(binder_and_pool: Tuple[FunctionBinder, MockConnec
         @binder.transaction()
         def should_raise_3(arg1: str):
             pass  # pragma: no cover
+
+
+def test_args_mismatch_raises(binder_and_pool: Tuple[FunctionBinder, MockConnectionPool]):
+    """Tests an error is raised if a template is bound to a function without a matching argument."""
+    binder, _ = binder_and_pool
+
+    with pytest.raises(MissingTemplateArgument, match="specified in template but is not an argument of"):
+
+        @binder.execute("INSERT INTO table (#{arg})")
+        def should_raise_4(some_arg: str):
+            pass

--- a/tests/binding/test_templating.py
+++ b/tests/binding/test_templating.py
@@ -2,6 +2,7 @@
 
 from typing import Tuple
 
+from dinao.binding.errors import TemplateError
 from dinao.binding.templating import Template
 
 import pytest
@@ -15,3 +16,16 @@ def test_valid_templates(init_args: Tuple[str], expected_sql: str, expected_args
     template = Template(*init_args)
     assert template.munged_sql == expected_sql
     assert template.arguments == expected_args
+
+
+def test_bad_template():
+    """Tests a bad template raises the appropariate error."""
+    raw_template = [
+        "INSERT INTO table VALUES (#{myarg1}, #{myarg2})",
+        "  ON CONFLICT DO UPDATE",
+        "SET mycol1 = #{myarg1",
+        "WHERE mycol2 = #{marg2}",
+    ]
+    raw_template = "\n".join(raw_template)
+    with pytest.raises(TemplateError, match="SET mycol1 = #{myarg1"):
+        Template(raw_template, "%s")


### PR DESCRIPTION
Closes #3.  There is more room for improvement, considering we're getting closer to a type of meta-programming we can probably muck with the trace back / stacks we show the user when we ultimately throw an error, the goal being to get them to the problematic line in their code quickly.  Right now the traces aren't so bad you can't tell whats going on and at least some guardrails are in place for some obvious errors.