### PR TITLE
Issue/#2 mapping

### DIFF
--- a/.pyspelling.xdic
+++ b/.pyspelling.xdic
@@ -18,6 +18,9 @@ concat
 conn
 contextlib
 contextmanager
+dataclass
+dataclasses
+datetime
 dbi
 dbname
 dinao
@@ -36,7 +39,9 @@ https
 ident
 impl
 init
+isclass
 isinstance
+iterable
 json
 jsonify
 kwarg
@@ -49,6 +54,7 @@ msg
 noqa
 ns
 num
+ok
 param
 params
 postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
       - aspell
       - aspell-en
 python:
-  - '3.7'
   - '3.8'
   - '3.9'
 before_install:

--- a/dinao/backend/__init__.py
+++ b/dinao/backend/__init__.py
@@ -20,7 +20,7 @@ def create_connection_pool(db_url: str) -> ConnectionPool:
 
     With different db_backends / drivers supporting additional arguments.
 
-    :return: A connection pool based on the given database URL.
+    :returns: A connection pool based on the given database URL.
     :raises: ConfigurationError, UnsupportedBackend
     """
     parsed_url = urlparse(db_url)

--- a/dinao/binding/errors.py
+++ b/dinao/binding/errors.py
@@ -19,6 +19,12 @@ class BindingError(Exception):
     pass
 
 
+class MappingError(Exception):
+    """Base exception for errors related to mapping database results to return types."""
+
+    pass
+
+
 class TemplateError(BindingError):
     """Raised when parsing a template fails."""
 
@@ -45,5 +51,23 @@ class BadReturnType(SignatureError):
 
 class MissingTemplateArgument(SignatureError):
     """Raised when a template specifies an argument not found in its bounded function's signature."""
+
+    pass
+
+
+class CannotInferMappingError(SignatureError):
+    """Raised when the return mapping for a bound function cannot be determined."""
+
+    pass
+
+
+class TooManyValuesError(MappingError):
+    """Raised when the number of columns does not match the expected number for mapping."""
+
+    pass
+
+
+class TooManyRowsError(MappingError):
+    """Raised when mapping implies a singular return, but many rows are returned."""
 
     pass

--- a/dinao/binding/mappers.py
+++ b/dinao/binding/mappers.py
@@ -1,0 +1,95 @@
+"""Mapper interface definition and stock implementations."""
+
+import collections
+import inspect
+import typing
+from abc import ABC, abstractmethod
+from datetime import datetime
+from uuid import UUID
+
+from dinao.backend.base import ColumnDescriptor
+from dinao.binding.errors import TooManyValuesError
+
+TUPLE_GENERICS = [tuple, typing.Tuple]
+GENERATOR_GENERICS = [collections.Generator, typing.Generator]
+DICT_GENERICS = [dict, typing.Dict, typing.Mapping, collections.Mapping]
+LIST_GENERICS = [list, typing.List, typing.Iterable, collections.Sequence, collections.Iterable]
+NATIVE_SINGLE = [str, int, float, complex, datetime, UUID]
+
+
+class RowMapper(ABC):
+    """Interface for database results mapper."""
+
+    @abstractmethod
+    def __call__(self, row: typing.Tuple, description: typing.Tuple[ColumnDescriptor, ...]):
+        """Map a database row to the type this implementation maps to.
+
+        :param row: a tuple of raw values from a database result set
+        :param description: the description of the row's columns
+
+        :returns: the row as the mapped type.
+        """
+        pass  # pragma: no cover
+
+
+class TupleRowMapper(RowMapper):
+    """Implements mapping for simply returning the raw result tuple with no casting."""
+
+    def __call__(self, row: typing.Tuple, description: typing.Tuple[ColumnDescriptor, ...]):  # noqa: D102
+        return row
+
+
+class DictRowMapper(RowMapper):
+    """Implements mapping for dictionaries where keys are string and values are not cast."""
+
+    def __call__(self, row: typing.Tuple, description: typing.Tuple[ColumnDescriptor, ...]):  # noqa: D102
+        return {d.name: row[col] for col, d in enumerate(description)}
+
+
+class ClassRowMapper(DictRowMapper):
+    """Implements mapping for classes where rows are passed as kwargs."""
+
+    def __init__(self, mapped_class):
+        """Construct a class row mapper by passing the row as named key word args to the class constructor.
+
+        :param mapped_class: the class to map a row to
+        """
+        self._mapped_class = mapped_class
+
+    def __call__(self, row: typing.Tuple, description: typing.Tuple[ColumnDescriptor, ...]):  # noqa: D102
+        kwargs = super().__call__(row, description)
+        return self._mapped_class(**kwargs)
+
+
+class SingleValueRowMapper(RowMapper):
+    """Implements a row mapper for a primitive type."""
+
+    def __call__(self, row: typing.Tuple, description: typing.Tuple[ColumnDescriptor, ...]):  # noqa: D102
+        if len(row) > 1:
+            raise TooManyValuesError(f"Too many values, expected 1, got {len(row)}")
+        return row[0]
+
+
+def get_row_mapper(row_type: typing.Type) -> typing.Optional[RowMapper]:
+    """Find the row mapper for the given row type.
+
+    :param row_type: the type to find a mapper for
+
+    :returns: a row mapper if one could be determined, None otherwise
+    """
+    generics_type = typing.get_origin(row_type)
+    generics_args = typing.get_args(row_type)
+    # Currently we don't support things like Tuple[str, int, ... ], Dict[str, int] etc ...
+    if generics_type and generics_args:
+        return None
+    elif row_type in TUPLE_GENERICS:
+        return TupleRowMapper()
+    elif row_type in DICT_GENERICS:
+        return DictRowMapper()
+    elif row_type in NATIVE_SINGLE:
+        return SingleValueRowMapper()
+    # Finally fall back to kwargs init
+    elif inspect.isclass(row_type):
+        return ClassRowMapper(row_type)
+    # Signal we don't know what to do
+    return None

--- a/examples/flask/app/api.py
+++ b/examples/flask/app/api.py
@@ -59,7 +59,7 @@ def listing():
     if limit < 1:
         return make_error("Bad page size")
     res = dbi.search(term, {"offset": (page * limit), "limit": limit})
-    res = jsonify({"results": [{name: value} for name, value in res]})
+    res = jsonify({"results": list(res)})
     return res, 200
 
 

--- a/examples/flask/app/dbi.py
+++ b/examples/flask/app/dbi.py
@@ -1,3 +1,5 @@
+from typing import Generator
+
 from dinao.binding import FunctionBinder
 
 binder = FunctionBinder()
@@ -27,22 +29,22 @@ def upsert(name: str, value: int) -> int:
     "SELECT name, value FROM data WHERE data.name LIKE #{search_term} " 
     "ORDER BY data.name LIMIT #{page.limit} OFFSET #{page.offset} "
 )
-def search(search_term: str, page: dict):
+def search(search_term: str, page: dict) -> Generator[dict, None, None]:
     pass
 
 
 @binder.transaction()
 def sum_for(search_term: str, page_size: int = 5) -> dict:
     page = {"limit": page_size, "offset": 0}
-    entries = search(search_term, page)
+    entries = list(search(search_term, page))
     summed = 0
     rows = 0
     pages = 0
     while entries:
         pages += 1
         for row in entries:
-            summed += row[1]
+            summed += row["value"]
             rows += 1
         page["offset"] += page["limit"]
-        entries = search(search_term, page)
+        entries = list(search(search_term, page))
     return {"summed": summed, "rows": rows, "pages": pages, "page_size": page_size}

--- a/setup.py
+++ b/setup.py
@@ -36,13 +36,13 @@ setup(
     test_suite="tests",
     install_requires=install_requires,
     tests_require=tests_require,
-    python_requires=">=3.7.0, <3.10",
+    python_requires=">=3.8.0, <3.11",
     extras_require={"tests": tests_require},
     classifiers=[
         "Topic :: Database",
         "Development Status :: 4 - Beta",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )

--- a/tests/backend/test_postgres_intg.py
+++ b/tests/backend/test_postgres_intg.py
@@ -27,7 +27,7 @@ def test_backend_impls(tmp_psql_db_url: str, extra_args: str):
     with cnx.query(test_sql.SIMPLE_SELECT, (6,)) as res:
         res: ResultSet = res
         row = res.fetchone()
-        assert ("my_pk_col", "some_uuid", "col_bigint", "col_integer") == res.columns()
+        assert ["my_pk_col", "some_uuid", "col_bigint", "col_integer"] == [r.name for r in res.description]
         assert (7, 14) == (row[2], row[3])
         assert 2 == len(res.fetchall())
     cnx_pool.release(cnx)

--- a/tests/backend/test_sqlite_intg.py
+++ b/tests/backend/test_sqlite_intg.py
@@ -21,7 +21,7 @@ def test_backend_impls(tmp_sqlite3_db_url: str):
     with cnx.query(test_sql.SIMPLE_SELECT, (6,)) as res:
         res: ResultSet = res
         row = res.fetchone()
-        assert ("my_pk_col", "some_uuid", "col_bigint", "col_integer") == res.columns()
+        assert ["my_pk_col", "some_uuid", "col_bigint", "col_integer"] == [r.name for r in res.description]
         assert (7, 14) == (row[2], row[3])
         assert 2 == len(res.fetchall())
     cnx_pool.release(cnx)

--- a/tests/binding/conftest.py
+++ b/tests/binding/conftest.py
@@ -1,0 +1,24 @@
+"""Helpful fixtures for testing dinao.binding functionality."""
+
+from dinao.binding import FunctionBinder
+
+import pytest
+
+from tests.binding.mocks import MockConnectionPool
+
+
+@pytest.fixture()
+def binder_and_pool(request):
+    """Fixture that yields a FunctionBinder (and its MockedConnectionPool) initialized with a set of MockResultSets.
+
+    .. note::
+        Can use the `indirect` parametrize functionality in fixture to specify the mocked results.
+    """
+    result_stack = []
+    if hasattr(request, "param"):
+        result_stack = request.param
+    pool = MockConnectionPool(result_stack)
+    binder = FunctionBinder()
+    binder.pool = pool
+    yield binder, pool
+    pool.dispose()

--- a/tests/binding/test_binders_errors.py
+++ b/tests/binding/test_binders_errors.py
@@ -39,7 +39,7 @@ def test_cannot_infer_nested_generic(binder_and_pool: Tuple[FunctionBinder, Mock
 
         @binder.query("SELECT * FROM table")
         def raises_cannot_infer_row_type() -> List[List[str]]:
-            pass   # pragma: no cover
+            pass  # pragma: no cover
 
 
 def test_binding_generator_throws(binder_and_pool: Tuple[FunctionBinder, MockConnectionPool]):

--- a/tests/binding/test_binders_errors.py
+++ b/tests/binding/test_binders_errors.py
@@ -1,0 +1,149 @@
+"""Tests various errors that can be thrown by binding."""
+
+from typing import Generator, List, Tuple, Union
+
+from dinao.binding import FunctionBinder
+from dinao.binding.binders import BoundedGeneratingQuery
+from dinao.binding.errors import (
+    BadReturnType,
+    CannotInferMappingError,
+    FunctionAlreadyBound,
+    MissingTemplateArgument,
+    NoPoolSetError,
+    PoolAlreadySetError,
+    TemplateError,
+)
+from dinao.binding.templating import Template
+
+import pytest
+
+from tests.binding.mocks import MockConnectionPool
+
+
+def test_cannot_infer_generic(binder_and_pool: Tuple[FunctionBinder, MockConnectionPool]):
+    """Tests that binding a function to typed generics raises an error."""
+    binder, _ = binder_and_pool
+
+    with pytest.raises(CannotInferMappingError, match="Unable to determine mapper for typing.Union"):
+
+        @binder.query("SELECT * FROM table")
+        def raises_cannot_infer() -> Union[str, int]:
+            pass  # pragma: no cover
+
+
+def test_cannot_infer_nested_generic(binder_and_pool: Tuple[FunctionBinder, MockConnectionPool]):
+    """Tests that binding a function to typed generics as row types raises."""
+    binder, _ = binder_and_pool
+
+    with pytest.raises(CannotInferMappingError, match="Unable to determine row mapper for typing.List\\[str\\]"):
+
+        @binder.query("SELECT * FROM table")
+        def raises_cannot_infer_row_type() -> List[List[str]]:
+            pass   # pragma: no cover
+
+
+def test_binding_generator_throws(binder_and_pool: Tuple[FunctionBinder, MockConnectionPool]):
+    """Tests that binding a function to generate when send type and return type are specified."""
+    binder, pool = binder_and_pool
+
+    with pytest.raises(CannotInferMappingError, match="Only yield_type"):
+
+        @binder.query("SELECT some_num FROM table LIMIT 3")
+        def generating_query_bad() -> Generator[int, int, int]:
+            pass  # pragma: no cover
+
+
+def test_bounded_generating_query_throws(binder_and_pool: Tuple[FunctionBinder, MockConnectionPool]):
+    """Tests that BoundedGeneratingQuery raises if not bound to a generator."""
+    binder, pool = binder_and_pool
+
+    def not_a_generator() -> int:
+        pass  # pragma: no cover
+
+    with pytest.raises(BadReturnType, match="Expected results type to be Generator"):
+        BoundedGeneratingQuery(binder, Template("SELECT * FROM table"), not_a_generator)
+
+
+def test_binder_execute_bad_type(binder_and_pool: Tuple[FunctionBinder, MockConnectionPool]):
+    """Tests that binding a function specifying an invalid return type for execution raises an exception."""
+    binder, _ = binder_and_pool
+
+    with pytest.raises(BadReturnType, match="can only return None or int"):
+
+        @binder.execute("INSERT INTO TABLE (#{arg1})")
+        def should_raise(arg1: str) -> List:
+            pass  # pragma: no cover
+
+
+def test_binder_raises_for_template(binder_and_pool: Tuple[FunctionBinder, MockConnectionPool]):
+    """Tests that a bad template causes an error at binding time."""
+    binder, _ = binder_and_pool
+
+    with pytest.raises(TemplateError, match="#{arg1"):
+
+        @binder.execute("INSERT INTO table #{arg1")
+        def should_raise_0(arg1: str) -> int:
+            pass  # pragma: no cover
+
+
+def test_double_binding_raises(binder_and_pool: Tuple[FunctionBinder, MockConnectionPool]):
+    """Tests that binding a function more than once results in an error."""
+    binder, _ = binder_and_pool
+    match = "has already been bounded by"
+
+    with pytest.raises(FunctionAlreadyBound, match=match):
+
+        @binder.execute("UPDATE table SET col = #{arg1}")
+        @binder.execute("INSERT INTO TABLE (#{arg1})")
+        def should_raise_1(arg1: str):
+            pass  # pragma: no cover
+
+    with pytest.raises(FunctionAlreadyBound, match=match):
+
+        @binder.execute("UPDATE table SET col = #{arg1}")
+        @binder.query("SELECT * FROM table WHERE col = #{arg1})")
+        def should_raise_2(arg1: str):
+            pass  # pragma: no cover
+
+    with pytest.raises(FunctionAlreadyBound, match=match):
+
+        @binder.execute("UPDATE table SET col = #{arg1}")
+        @binder.transaction()
+        def should_raise_3(arg1: str):
+            pass  # pragma: no cover
+
+
+def test_args_mismatch_raises(binder_and_pool: Tuple[FunctionBinder, MockConnectionPool]):
+    """Tests an error is raised if a template is bound to a function without a matching argument."""
+    binder, _ = binder_and_pool
+
+    with pytest.raises(MissingTemplateArgument, match="specified in template but is not an argument of"):
+
+        @binder.execute("INSERT INTO table (#{arg})")
+        def should_raise_4(some_arg: str):
+            pass  # pragma: no cover
+
+
+def test_binder_raises_for_no_pool():
+    """Tests an error is raised when a bind has no pool but an operation requiring one is performed."""
+    binder = FunctionBinder()
+
+    @binder.execute("INSERT INTO table (#{arg})")
+    def test_bound_execute(arg: str):
+        pass  # pragma: no cover
+
+    with pytest.raises(NoPoolSetError, match="No connection pool"):
+        test_bound_execute("testing")
+
+    with pytest.raises(NoPoolSetError, match="No connection pool"):
+        with binder.connection() as cnx:  # noqa: F841
+            pass  # pragma: no cover
+
+
+def test_binder_raises_for_pool_set_twice(binder_and_pool: Tuple[FunctionBinder, MockConnectionPool]):
+    """Tests an error is raised when a binder has its pool set twice."""
+    binder, _ = binder_and_pool
+    pool = MockConnectionPool([])
+
+    with pytest.raises(PoolAlreadySetError, match="only be set once"):
+        binder.pool = pool

--- a/tests/binding/test_mapping.py
+++ b/tests/binding/test_mapping.py
@@ -1,0 +1,108 @@
+"""Tests basic functionality of dinao.binding.mappers module."""
+
+import dataclasses
+from datetime import datetime
+from typing import Dict, Mapping, Optional, Tuple, Union
+from uuid import UUID
+
+from dinao.backend.base import ColumnDescriptor
+from dinao.binding.errors import TooManyValuesError
+from dinao.binding.mappers import ClassRowMapper, DictRowMapper, SingleValueRowMapper, TupleRowMapper, get_row_mapper
+
+import pytest
+
+
+@dataclasses.dataclass()
+class SomeDataClass:
+    """Data class for testing mappers."""
+
+    field_01: str
+    field_02: int
+
+
+class SomeClass:
+    """Regular class for testing mappers."""
+
+    pass
+
+
+@pytest.mark.parametrize(
+    "row_type, expected",
+    (
+        (str, SingleValueRowMapper),
+        (int, SingleValueRowMapper),
+        (float, SingleValueRowMapper),
+        (complex, SingleValueRowMapper),
+        (datetime, SingleValueRowMapper),
+        (UUID, SingleValueRowMapper),
+        (tuple, TupleRowMapper),
+        (Tuple, TupleRowMapper),
+        (dict, DictRowMapper),
+        (Dict, DictRowMapper),
+        (Mapping, DictRowMapper),
+        (SomeClass, ClassRowMapper),
+        (SomeDataClass, ClassRowMapper),
+    ),
+)
+def test_get_row_mapper(row_type, expected):
+    """Tests get_row_mapper for known mappings."""
+    assert isinstance(get_row_mapper(row_type), expected)
+
+
+@pytest.mark.parametrize(
+    "row_type",
+    (
+        Mapping[str, int],
+        Tuple[str, ...],
+        Union,
+        Union[str, int],
+        Optional,
+        Optional[str],
+    ),
+)
+def test_get_unknown_mappers(row_type):
+    """Tests get_row_mapper for unknown mappings."""
+    assert get_row_mapper(row_type) is None
+
+
+def test_dict_row_mapper():
+    """Tests the DictRowMapper class."""
+    mapper = DictRowMapper()
+    descriptions = (
+        ColumnDescriptor("field_01", 0),
+        ColumnDescriptor("field_02", 1),
+        ColumnDescriptor("field_03", 3),
+    )
+    actual = mapper((0, "test", 3.0), descriptions)
+    assert actual == {"field_01": 0, "field_02": "test", "field_03": 3.0}
+
+
+def test_class_row_mapper():
+    """Tests the ClassRowMapper class."""
+    mapper = ClassRowMapper(SomeDataClass)
+    descriptions = (
+        ColumnDescriptor("field_01", 0),
+        ColumnDescriptor("field_02", 1),
+    )
+    actual = mapper(("test", 20), descriptions)
+    assert isinstance(actual, SomeDataClass)
+    assert actual.field_01 == "test"
+    assert actual.field_02 == 20
+
+
+def test_single_value_row_mapper():
+    """Tests the SingleValueRowMapper class."""
+    mapper = SingleValueRowMapper()
+    descriptions = (ColumnDescriptor("field_01", 0),)
+    assert mapper(("test",), descriptions) == "test"
+
+
+def test_single_value_row_mapper_throws():
+    """Tests the SingleValueRowMapper class throws when there are to many columns."""
+    mapper = SingleValueRowMapper()
+    descriptions = (
+        ColumnDescriptor("field_01", 0),
+        ColumnDescriptor("field_02", 1),
+    )
+    with pytest.raises(TooManyValuesError, match="expected 1, got 2"):
+        mapper((3.0, 4.0), descriptions)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39
+envlist = py38,py39
 
 [flake8]
 max-line-length = 120
@@ -15,8 +15,7 @@ deps =
     pydocstyle
     pygments
     black==20.8b1
-    # TODO: Remove this when 2.7.1 is released
-    git+https://github.com/facelessuser/pyspelling.git
+    pyspelling==2.7.1
 commands =
     flake8 ./dinao/ ./tests/ setup.py
     black . --line-length 120 --check --diff --exclude examples/


### PR DESCRIPTION
Closes #2 

* Interface on the backend classes changes (columns went away in favor of a wrapper over cursor descriptions)
* Dropped 3.7 support because generic checking is thorny there
* Added **basic** mapping support, a lot of room for improvement around column value adapting, checking values, and expected column count vs actual column count.
* Fixed some misc. doc strings.