### PR TITLE
Auto commit should be off in transactions

### DIFF
--- a/.pyspelling.xdic
+++ b/.pyspelling.xdic
@@ -5,6 +5,7 @@ api
 arg
 args
 atexit
+autocommit
 backend
 backends
 bool

--- a/dinao/backend/base.py
+++ b/dinao/backend/base.py
@@ -85,6 +85,15 @@ class Connection(ABC):
         self._cnx = cnx
         self._auto_commit = auto_commit
 
+    @property
+    def autocommit(self):
+        """Whether or not commit is called after every call to query(...) and execute(...)."""
+        return self._auto_commit
+
+    @autocommit.setter
+    def autocommit(self, value: bool):
+        self._auto_commit = value
+
     def commit(self):
         """Commit changes for this connection / transaction to the database."""
         self._cnx.commit()

--- a/dinao/binding/binders.py
+++ b/dinao/binding/binders.py
@@ -419,6 +419,7 @@ class BoundedTransaction(BoundedFunction):
         :param kwargs: the keyword arguments of the bounded / decorated function
         """
         with self._binder.connection() as cnx:
+            cnx.autocommit = False
             if self._cnx_arg_name:
                 kwargs = kwargs or {}
                 kwargs[self._cnx_arg_name] = cnx

--- a/tests/binding/mocks.py
+++ b/tests/binding/mocks.py
@@ -108,6 +108,8 @@ class MockConnection(Connection):
     def query(self, sql: str, params: tuple = None) -> ResultSet:  # noqa: D102
         self.query_stack.append((sql, params))
         self.queries += 1
+        if self.autocommit:
+            self.commit()
         if not self.cursor_stack:  # pragma: no cover
             msg = f"Mocked results exhausted: query(sql={sql}, params={params}), call number {self.queries}"
             raise Exception(msg)
@@ -116,6 +118,9 @@ class MockConnection(Connection):
 
     def execute(self, sql: str, params: tuple = None, commit: bool = None) -> int:  # noqa: D102
         self.query_stack.append((sql, params))
+        commit = commit if commit is not None else self._auto_commit
+        if commit:
+            self.commit()
         self.executions += 1
         if not self.cursor_stack:  # pragma: no cover
             msg = f"Mocked results exhausted: execute(sql={sql}, params={params}), call number {self.executions}"

--- a/tests/binding/test_binders.py
+++ b/tests/binding/test_binders.py
@@ -221,6 +221,7 @@ def test_binder_passes_cnx(binder_and_pool: Tuple[FunctionBinder, MockConnection
     assert len(pool.connection_stack) == 1
     cnx: MockConnection = pool.connection_stack.pop(0)
     cnx.assert_clean()
+    assert cnx.committed == 1
     assert cnx.query_stack == [
         ("DELETE FROM table", ()),
         ("INSERT INTO table (%s), (%s)", (1, 2)),


### PR DESCRIPTION
Commits for a function bound with transaction(..) should only occur when the function context is exited, if the user wants to change this behavior, or commit mid execution, they can specify a connection argument on the function.