### PR TITLE
Peg to working versions, fix port on mac

### DIFF
--- a/examples/flask/Dockerfile
+++ b/examples/flask/Dockerfile
@@ -1,14 +1,14 @@
-FROM python:3.10.8
+FROM python:3.12
 WORKDIR /usr/src/app
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 RUN apt-get update -y
-RUN apt-get install -y netcat
+RUN apt-get install netcat-openbsd
 RUN pip install --upgrade pip
-RUN pip install flask
+RUN pip install flask==2.2.5
 RUN pip install psycopg2-binary
-RUN pip install gunicorn
+RUN pip install gunicorn==20.1.0
 
 COPY ./dinao-tmp/ /dinao/
 RUN pip install /dinao/

--- a/examples/flask/build.sh
+++ b/examples/flask/build.sh
@@ -2,7 +2,7 @@
 set -e
 
 SRC_PATH=`readlink -f ../../`
-CP_FILES="${SRC_PATH}/requirements.txt ${SRC_PATH}/setup.py ${SRC_PATH}/README.rst"
+CP_FILES="${SRC_PATH}/pyproject.toml"
 TEMP_DIR="./dinao-tmp/"
 
 function cleanup {

--- a/examples/flask/docker-compose.yaml
+++ b/examples/flask/docker-compose.yaml
@@ -16,4 +16,4 @@ services:
     depends_on:
       - postgres
     ports:
-      - "5000:5000"
+      - "5001:5000"

--- a/examples/flask/entry.sh
+++ b/examples/flask/entry.sh
@@ -16,4 +16,4 @@ done
 echo "Running ini"
 python3 ./ini.py
 echo "Starting gunicorn"
-gunicorn --preload -w 5 --bind 0.0.0.0:5000 api:app
+gunicorn --preload -w 5 --bind 0.0.0.0:5000 "api:app"

--- a/examples/flask/tester.py
+++ b/examples/flask/tester.py
@@ -14,7 +14,7 @@ class Smacker(threading.Thread):
     def __init__(self, worker_num: int):
         super().__init__()
         self.shutdown_flag = threading.Event()
-        self.api = "http://localhost:5000/"
+        self.api = "http://localhost:5001/"
         self.worker_num = worker_num
 
     def _api_action(self) -> requests.Response:


### PR DESCRIPTION
- Get example with flask working again
- For now band-aid by pegging to last working versions of flask+gunicorn.  The example needs modernization. 
- Change the port the container runs it's webserver on so that it works on mac when stupid CommandCenter / AirPlay is running on port 5k. 