### PR TITLE
Typo in last release

### DIFF
--- a/dinao/__version__.py
+++ b/dinao/__version__.py
@@ -1,2 +1,2 @@
 # noqa: D100
-__version__ = "2.2.0"
+__version__ = "2.1.0"


### PR DESCRIPTION
Deleted the erroneous release in pypi, fixing this now on GH 